### PR TITLE
Allow arguments for command and never use shell

### DIFF
--- a/valprod/bin/jMonitor
+++ b/valprod/bin/jMonitor
@@ -24,7 +24,7 @@ def getParser():
   argParser.add_argument('-m', '--histtest-method', dest='histtestmeth', choices=['Kolmogorov', 'Chi2'], default='Kolmogorov', help='Method of histogram testing')
   argParser.add_argument('-c', '--histtest-cut', dest='histtestcut', type=float, default='0.9', help='P-Value cut for histogram testing')
   # cmd
-  argParser.add_argument('command', help='job to be monitored')
+  argParser.add_argument('command', nargs='+', help='job to be monitored')
   argParser.add_argument('--gen-log', dest='log', action='store_true', help='whether to generate log file')
   argParser.add_argument('-n', '--name', dest='name', default="TEST", help='name of the job')
 

--- a/valprod/utils/TestConfig.py
+++ b/valprod/utils/TestConfig.py
@@ -13,7 +13,6 @@ class TestConfig:
                'VIRMonitor' : False,
                'timeInterval' : 0.5,
                'MonBackend': 'root',
-               'shell' : True,
                'fatalPattern' : None,
                'plotRef' : None,
                'cmpOutput' : 'plotcmp.root',

--- a/valprod/workflow/MonitoredProcess.py
+++ b/valprod/workflow/MonitoredProcess.py
@@ -27,8 +27,9 @@ class MonitoredProcess(Process, BaseMonitor):
 
   def run(self):
     print('Running test: %s' % self.name)
+    print(self.executable)
     self.start = datetime.datetime.now()
-    self.process = subprocess.Popen(args = self.executable, shell = self.shell, stdout = self.stdout, stderr = self.stderr)
+    self.process = subprocess.Popen(args = self.executable, stdout = self.stdout, stderr = self.stderr)
     self.pid = self.process.pid
     while True:
       time.sleep(self.interval)

--- a/valprod/workflow/Process.py
+++ b/valprod/workflow/Process.py
@@ -27,12 +27,7 @@ class Process:
     self.cfg = cfg
     self.name = name or 'test'
     self.logParser = cfg.getAttr('parser') and Parser(cfg) or None
-    if self.cfg.getAttr('shell'):
-      self.executable = exe
-      self.shell = True
-    else:
-      self.executable = exe.split()
-      self.shell = False
+    self.executable = exe
     self.genLog = self.cfg.getAttr('genLog')
 
     # Log file name depends on what we are running
@@ -58,7 +53,7 @@ class Process:
   def run(self):
     print('Running test: %s' % self.name)
     self.start = datetime.datetime.now()
-    self.process = subprocess.Popen(args = self.executable, shell = self.shell, stdout = self.stdout, stderr = subprocess.STDOUT)
+    self.process = subprocess.Popen(args = self.executable, stdout = self.stdout, stderr = subprocess.STDOUT)
     self.pid = self.process.pid
     if self.genLog:
       # TODO


### PR DESCRIPTION
Allow remaining arguments on the command line to be multivalued, so that they can be passed to the executed process. This works with the standard syntax of `--` which interrupts jMonitor from trying to take the arguments itself.

Remove the shell execution option internally and always execute directly.

It is no longer necessary to *quote* the arguments to the monitored process so that the previous use of, e.g.,

```sh
jMonitor "runSim --input data*"
```

should now be

```sh
jMonitor -- runSim --input data*
```

The user's shell will take care of globbing, if needed.

Closes #1 
Closes #2 

BEGINRELEASENOTES
Move to standard way to pass arguments to the monitored process
Always use direct execution for the subprocess, don't use a subshell
ENDRELEASENOTES
