### PR TITLE
Proof of concept of delegating monitoring to prmon

### DIFF
--- a/valprod/utils/monitors.py
+++ b/valprod/utils/monitors.py
@@ -26,6 +26,15 @@ class PidMonitor():
       self.max = value
     self.results.append(value)
 
+  def push(self, value):
+    '''Push an external value into the monitored results list'''
+    if value < self.min:
+      self.min = value
+    if value > self.max:
+      self.max = value
+    print(f'Pushed {value} to {self.test_name}')
+    self.results.append(value)
+
   def done(self):
     if self.backend == 'matplotlib':
       import matplotlib.pyplot as plt

--- a/valprod/workflow/MonitoredProcess.py
+++ b/valprod/workflow/MonitoredProcess.py
@@ -3,6 +3,7 @@
 
 import subprocess
 import time, datetime, os
+import json
 from valprod.utils.monitors import *
 from valprod.workflow.Process import Process,status
 
@@ -18,6 +19,8 @@ class MonitoredProcess(Process, BaseMonitor):
     assert self.interval <= 10 and self.interval >= 0.3, 'attribute time interval must be a number between 0.3 and 10'
 
     # Create monitors
+
+    # PRMON testing - we do set these up for compatibility, but they will be filled in a different way
     monitor_map = {'CPUMonitor': CpuMonitor, 'VIRMonitor': VirtMonitor, 'RESMonitor': ResMonitor}
     for k,v in monitor_map.items():
       if self.cfg.getAttr(k):
@@ -31,12 +34,36 @@ class MonitoredProcess(Process, BaseMonitor):
     self.start = datetime.datetime.now()
     self.process = subprocess.Popen(args = self.executable, stdout = self.stdout, stderr = self.stderr)
     self.pid = self.process.pid
+
+    # Patch to use prmon, once we know the PID of the main monitored
+    # task we ask prmon to monitor it for us
+    prmon_interval = int(self.interval) if int(self.interval) > 0 else 1
+    prmon_cmd = ['prmon', '--interval', str(prmon_interval), '--pid', str(self.pid)]
+    prmon_subprocess = subprocess.Popen(args = prmon_cmd)
     while True:
       time.sleep(self.interval)
       if not self.process.poll() == None:
         break
-      for monitor in self.monitorList:
-        monitor.do(self.pid)
+      # PRMON loop - read the JSON snapshot file
+      try:
+        with open('prmon.json_snapshot') as prmon_snapshot:
+          prmon_json = json.load(prmon_snapshot)
+          print(prmon_json)
+          # Now loop over each of the old style monitor classes and push in a prmon value
+          # (This selection code scales horribly - convert to a dictionary!)
+          for monitor in self.monitorList:
+            print(monitor.monitor_name)
+            if monitor.monitor_name == 'CPURate':
+              monitor.push(prmon_json['Max']['utime'] + prmon_json['Max']['stime'])
+            elif monitor.monitor_name == 'VirMem':
+              monitor.push(prmon_json['Max']['vmem'])
+            elif monitor.monitor_name == 'ResMem':
+              monitor.push(prmon_json['Max']['rss'])
+      except FileNotFoundError:
+        print("Snapshot not found")
+        pass
+      except json.JSONDecodeError as e:
+        print(f"Error decoding JSON: {e.msg}")
       if not self._checkLimit():
         break
     for monitor in self.monitorList:


### PR DESCRIPTION
Show how prmon can be used as an external resource monitor for jMonitor
- prmon is invoked after the main process is spawned and monitors it
  and all of its children
- the prmon "snapshot" file is read on each monitoring cycle to read
  current resource values
- these values are pushed into the current jMonitor VirtMonitor classes
  (using a new method, push())

This only a proof of concept to show the idea, I wouldn't use this code
in its current form.

The content of the current prmon snapshot file isn't quite a match to
what jMonitor uses, but it could rather easily be ammended (the final
prmon txt file does contain everything needed, but it's much more
awkward to parse on the fly).

In particular:
- prmon doesn't measure CPU rate, but instead measures cummulative
  consuption time (user + system) so for now this has been used as a
  proxy in the CPURate monitor.
- the VMEM and RSS values are strictly the Max values at the moment,
  so they are monotonic increasing; prmon could easily output the
  correct snapshot values if needed


BEGINRELEASENOTES
- Thank you for writing the text to appear in the release notes. It will show up
  exactly as it appears between the two bold lines
- ...

ENDRELEASENOTES
